### PR TITLE
Fix `test` and `start` scripts on `packages.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npm build;mocha --recursive build/tests/",
+    "test": "npm run build; mocha --recursive build/tests/",
     "coverage": "nyc -r html --require babel-core/register npm test",
-    "start": "npm build;node build/src/app.js",
+    "start": "npm run build; node build/src/app.js",
     "build": "babel src/ -d build/src; babel tests/ -d build/tests"
   },
   "author": "",


### PR DESCRIPTION
When you run `npm build` it isn't executing the script defined on `packages.json` (http://stackoverflow.com/questions/29939697/npm-build-doesnt-run-the-script-named-build-in-package-json). 

To execute the script correctly it must be done via `npm run build`.