### PR TITLE
Fix docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,28 @@ FROM node:9.5.0
 RUN mkdir -p /diffy/backend
 RUN mkdir -p /diffy/frontend
 
-# Frontend
+# Frontend dependencies
 COPY ./frontend/package.json /diffy/frontend/
 WORKDIR /diffy/frontend
 RUN npm install
+
 # Angular stuff (cli and dev)
 RUN npm install -g @angular/cli
 
-# Backend
+# Backend dependencies
 COPY ./backend/package.json /diffy/backend/
 WORKDIR /diffy/backend
 RUN npm install
 
+COPY ./backend /diffy/backend/
+COPY ./frontend /diffy/frontend/
+
+WORKDIR /diffy/frontend
+RUN npm run-script build
+
 # By default expose port 3000 and run `node /diffy/src/app.js` when executing the image
 EXPOSE 3000
+WORKDIR /diffy/backend
+
+COPY ./ /diffy/
 CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     image: diffy
     ports:
       - 3000:3000
-    volumes:
-      - .:/diffy
-      - diffy-vol-be:/diffy/backend/node_modules
-      - diffy-vol-fe:/diffy/frontend/node_modules
     links:
       - db
     environment:
@@ -18,10 +14,6 @@ services:
     stop_signal: SIGINT
   db:
     image: mongo:latest
-    volumes:
       - ./data:/data/db
     ports:
       - 27017:27017
-volumes:
-  diffy-vol-be:
-  diffy-vol-fe:


### PR DESCRIPTION
Hey there.

I was trying to set up diffy with Docker. While all tests pass and it builds successfully, the resulting app doesn't. The issue is that is missing the frontend build, which is not happening in the dockerfile.

I'm guessing it went unnoticed, because there is a volume for `./:/diffy` and you likely have a built frontend on dist, which the docker server happily uses.

Tried to re-order a bit the Dockerfile to take advantage of layer caching, as well.
Let me know if there's something you think needs modifying.