### PR TITLE
The cart goes behind the horse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,27 +4,30 @@ FROM node:16.7.0
 RUN mkdir -p /diffy/backend
 RUN mkdir -p /diffy/frontend
 
-RUN npm install -g typescript@4.3.5
+RUN npm install -g typescript@4.3.5 --legacy-peer-deps
 # Angular stuff (cli and dev)
-RUN npm install -g @angular/cli@12.2.2
+RUN npm install -g @angular/cli@12.2.2 --legacy-peer-deps
+
+COPY ./models/ /diffy/models/
+COPY ./backend/ /diffy/backend/
+COPY ./frontend/ /diffy/frontend/
+
+# Models
+WORKDIR /diffy/models
+RUN npm install
+RUN npm run-script build
 
 # Frontend
-COPY ./frontend/ /diffy/frontend/
 WORKDIR /diffy/frontend
 RUN npm install --legacy-peer-deps
 RUN npm run-script build
 
 # Backend
-COPY ./backend/ /diffy/backend/
 WORKDIR /diffy/backend
 RUN npm install
 RUN npm run-script build
 
-# Models
-COPY ./models/ /diffy/models/
-WORKDIR /diffy/models
-RUN npm install
-RUN npm run-script build
+
 
 # By default expose port 3000 and run `node /diffy/src/app.js` when executing the image
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
 version: "2"
 services:
   web:
-    build: ./
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: diffy
     ports:
       - 3000:3000
     volumes:
-      - .:/diffy
+      - ./:/diffy
     environment:
       - DIFFY_WEB_HOST=0.0.0.0
       - DIFFY_GA_ANALYTICS_KEY=none


### PR DESCRIPTION
update Dockerfile and docker-compose.yml so that diffy-models are where the backend expects them. This addresses issues raised by [F0x06](https://github.com/pbu88/diffy/issues/89) and [aeifr](https://github.com/pbu88/diffy/issues/36)